### PR TITLE
Allow AIProperty to infer key-path names

### DIFF
--- a/Tests/SwiftHablareTests/Core/AIGeneratableTests.swift
+++ b/Tests/SwiftHablareTests/Core/AIGeneratableTests.swift
@@ -14,18 +14,18 @@ struct AIGeneratableTests {
 
         static var aiGenerationSchema: AIGenerationSchema {
             AIGenerationSchema {
-                AIProperty(\TestArticle.title, name: "title")
+                Self.AIProperty(\.title)
                     .providers(["openai", "anthropic"])
                     .constraints(minLength: 10, maxLength: 100)
                     .promptTemplate("Generate a title for: {content}")
                     .required()
 
-                AIProperty(\TestArticle.content, name: "content")
+                Self.AIProperty(\.content)
                     .providers(["openai"])
                     .constraints(minLength: 100, maxLength: 5000)
                     .optional()
 
-                AIProperty(\TestArticle.summary, name: "summary")
+                Self.AIProperty(\.summary)
                     .providers(["openai", "anthropic"])
                     .inputProperty("content")
                     .constraints(maxLength: 200)
@@ -48,7 +48,7 @@ struct AIGeneratableTests {
 
     @Test("AIProperty stores property information correctly")
     func testAIPropertySpec() {
-        let property = AIProperty(\TestArticle.title, name: "title")
+        let property = AIProperty(\TestArticle.title)
             .providers(["openai", "anthropic"])
             .constraints(minLength: 10, maxLength: 100)
             .promptTemplate("Test template")
@@ -64,7 +64,7 @@ struct AIGeneratableTests {
 
     @Test("AIProperty optional() method works")
     func testAIPropertyOptional() {
-        let property = AIProperty(\TestArticle.content, name: "content")
+        let property = AIProperty(\TestArticle.content)
             .optional()
 
         #expect(property.required == false)
@@ -72,7 +72,7 @@ struct AIGeneratableTests {
 
     @Test("AIProperty inputProperty works")
     func testAIPropertyInputProperty() {
-        let property = AIProperty(\TestArticle.summary, name: "summary")
+        let property = AIProperty(\TestArticle.summary)
             .inputProperty("content")
 
         #expect(property.inputPropertyName == "content")
@@ -80,7 +80,7 @@ struct AIGeneratableTests {
 
     @Test("AIProperty addConstraint works")
     func testAIPropertyAddConstraint() {
-        let property = AIProperty(\TestArticle.title, name: "title")
+        let property = AIProperty(\TestArticle.title)
             .addConstraint(key: "tone", value: "professional")
             .addConstraint(key: "format", value: "markdown")
 
@@ -91,9 +91,9 @@ struct AIGeneratableTests {
     @Test("AIGenerationSchemaBuilder builds correctly")
     func testSchemaBuilder() {
         let schema = AIGenerationSchema {
-            AIProperty(\TestArticle.title, name: "title")
-            AIProperty(\TestArticle.content, name: "content")
-            AIProperty(\TestArticle.summary, name: "summary")
+            TestArticle.AIProperty(\.title)
+            TestArticle.AIProperty(\.content)
+            TestArticle.AIProperty(\.summary)
         }
 
         #expect(schema.properties.count == 3)
@@ -105,8 +105,8 @@ struct AIGeneratableTests {
     @Test("AIGenerationSchema can be constructed directly")
     func testSchemaDirectConstruction() {
         let properties = [
-            AIProperty(\TestArticle.title, name: "title"),
-            AIProperty(\TestArticle.content, name: "content")
+            AIProperty(\TestArticle.title),
+            AIProperty(\TestArticle.content)
         ]
 
         let schema = AIGenerationSchema(properties: properties)
@@ -136,7 +136,7 @@ struct AIGeneratableTests {
 
     @Test("AIPropertySpec builder methods are chainable")
     func testPropertySpecChaining() {
-        let property = AIProperty(\TestArticle.title, name: "title")
+        let property = AIProperty(\TestArticle.title)
             .providers(["openai"])
             .constraints(minLength: 5, maxLength: 50)
             .promptTemplate("Generate: {title}")
@@ -154,7 +154,7 @@ struct AIGeneratableTests {
 
     @Test("AIProperty without constraints")
     func testAIPropertyWithoutConstraints() {
-        let property = AIProperty(\TestArticle.title, name: "title")
+        let property = AIProperty(\TestArticle.title)
 
         #expect(property.propertyName == "title")
         #expect(property.allowedProviders.isEmpty)
@@ -169,7 +169,7 @@ struct AIGeneratableTests {
 
     @Test("AIPropertySpec is Sendable")
     func testAIPropertySpecSendable() async {
-        let property = AIProperty(\TestArticle.title, name: "title")
+        let property = AIProperty(\TestArticle.title)
 
         await Task {
             // Should compile without warnings due to Sendable conformance
@@ -197,11 +197,11 @@ struct AIGeneratableTests {
         #expect(articleSchema.properties[2].propertyName == "summary")
     }
 
-    @Test("Property names are explicitly specified")
+    @Test("Property names are derived from key paths")
     func testPropertyNameExtraction() {
-        let titleProp = AIProperty(\TestArticle.title, name: "title")
-        let contentProp = AIProperty(\TestArticle.content, name: "content")
-        let summaryProp = AIProperty(\TestArticle.summary, name: "summary")
+        let titleProp = AIProperty(\TestArticle.title)
+        let contentProp = AIProperty(\TestArticle.content)
+        let summaryProp = AIProperty(\TestArticle.summary)
 
         #expect(titleProp.propertyName == "title")
         #expect(contentProp.propertyName == "content")
@@ -211,7 +211,7 @@ struct AIGeneratableTests {
     @Test("Constraints only for strings")
     func testConstraintsOnlyForStrings() {
         // This test verifies that constraints are optional and can be omitted
-        let property = AIProperty(\TestArticle.title, name: "title")
+        let property = AIProperty(\TestArticle.title)
             .providers(["openai"])
 
         #expect(property.minLength == nil)
@@ -221,5 +221,12 @@ struct AIGeneratableTests {
         let constrained = property.constraints(minLength: 10, maxLength: 100)
         #expect(constrained.minLength == 10)
         #expect(constrained.maxLength == 100)
+    }
+
+    @Test("AIProperty infers property names when omitted")
+    func testAIPropertyNameInference() {
+        let inferred = TestArticle.AIProperty(\.summary)
+
+        #expect(inferred.propertyName == "summary")
     }
 }


### PR DESCRIPTION
## Summary
- allow AIProperty to infer property names from key paths when an explicit name is omitted
- add a convenience helper on AIGeneratable for Self-relative key path declarations
- update AIGeneratable tests to cover inferred names and new helper usage

## Testing
- swift test *(fails: package requires Swift tools 6.2.0 but environment provides 6.1.0)*

------
https://chatgpt.com/codex/tasks/task_e_68eaef3fb2248321ac48a57cf4f0744c