### PR TITLE
Isolate AIServiceManager tests from shared singleton state

### DIFF
--- a/Sources/SwiftHablare/Core/AIServiceManager.swift
+++ b/Sources/SwiftHablare/Core/AIServiceManager.swift
@@ -51,7 +51,12 @@ public actor AIServiceManager {
     // MARK: - Initialization
 
     /// Private initializer to enforce singleton pattern.
-    private init() {}
+    /// Creates a new service manager instance.
+    ///
+    /// While the framework primarily exposes the shared singleton via ``shared``,
+    /// tests can initialize isolated instances to avoid cross-test interference
+    /// when running in parallel.
+    internal init() {}
 
     // MARK: - Registration
 

--- a/Tests/SwiftHablareTests/Manager/AIServiceManagerConcurrencyTests.swift
+++ b/Tests/SwiftHablareTests/Manager/AIServiceManagerConcurrencyTests.swift
@@ -6,11 +6,17 @@ import Foundation
 @Suite(.serialized)
 struct AIServiceManagerConcurrencyTests {
 
+    /// Creates an isolated manager instance for each test to prevent shared-state
+    /// interference when the test suite executes in parallel with others.
+    private func makeManager() -> AIServiceManager {
+        AIServiceManager()
+    }
+
     // MARK: - Concurrent Registration Tests
 
     @Test("AIServiceManager handles concurrent registration safely")
     func testConcurrentRegistration() async throws {
-        let manager = AIServiceManager.shared
+        let manager = makeManager()
         await manager.unregisterAll()
 
         // Wait longer to ensure cleanup completes in CI and other suites finish
@@ -52,7 +58,7 @@ struct AIServiceManagerConcurrencyTests {
 
     @Test("AIServiceManager handles concurrent unregistration safely")
     func testConcurrentUnregistration() async throws {
-        let manager = AIServiceManager.shared
+        let manager = makeManager()
         await manager.unregisterAll()
 
         // Wait longer to ensure cleanup completes in CI and other suites finish
@@ -102,7 +108,7 @@ struct AIServiceManagerConcurrencyTests {
 
     @Test("AIServiceManager handles concurrent mixed operations safely")
     func testConcurrentMixedOperations() async throws {
-        let manager = AIServiceManager.shared
+        let manager = makeManager()
         await manager.unregisterAll()
 
         // Perform mixed operations concurrently
@@ -147,7 +153,7 @@ struct AIServiceManagerConcurrencyTests {
 
     @Test("AIServiceManager handles concurrent queries safely")
     func testConcurrentQueries() async throws {
-        let manager = AIServiceManager.shared
+        let manager = makeManager()
         await manager.unregisterAll()
 
         // Register some providers
@@ -189,7 +195,7 @@ struct AIServiceManagerConcurrencyTests {
 
     @Test("AIServiceManager handles registration/unregistration races")
     func testRegistrationUnregistrationRace() async throws {
-        let manager = AIServiceManager.shared
+        let manager = makeManager()
         await manager.unregisterAll()
 
         let providerID = "race-provider"
@@ -234,7 +240,7 @@ struct AIServiceManagerConcurrencyTests {
 
     @Test("AIServiceManager maintains index consistency under concurrent access")
     func testIndexConsistencyUnderConcurrency() async throws {
-        let manager = AIServiceManager.shared
+        let manager = makeManager()
         await manager.unregisterAll()
 
         // Register and unregister providers concurrently

--- a/Tests/SwiftHablareTests/Manager/AIServiceManagerIntegrationTests.swift
+++ b/Tests/SwiftHablareTests/Manager/AIServiceManagerIntegrationTests.swift
@@ -6,6 +6,12 @@ import Foundation
 @Suite(.serialized)
 struct AIServiceManagerIntegrationTests {
 
+    /// Creates an isolated manager per test to avoid shared-state interference
+    /// across suites that may execute in parallel.
+    private func makeManager() -> AIServiceManager {
+        AIServiceManager()
+    }
+
     // MARK: - Test Model
 
     @Model
@@ -25,7 +31,7 @@ struct AIServiceManagerIntegrationTests {
 
     @Test("Provider lifecycle: register → query → use → unregister")
     func testProviderLifecycle() async throws {
-        let manager = AIServiceManager.shared
+        let manager = makeManager()
         await manager.unregisterAll()
         try await Task.sleep(nanoseconds: 100_000_000) // 100ms for CI stability
 
@@ -56,7 +62,7 @@ struct AIServiceManagerIntegrationTests {
 
     @Test("Multiple providers can be registered and queried simultaneously")
     func testMultipleProvidersSimultaneously() async throws {
-        let manager = AIServiceManager.shared
+        let manager = makeManager()
         await manager.unregisterAll()
 
         // Wait for cleanup to complete
@@ -89,7 +95,7 @@ struct AIServiceManagerIntegrationTests {
 
     @Test("Provider replacement updates all indices correctly")
     func testProviderReplacementUpdatesIndices() async throws {
-        let manager = AIServiceManager.shared
+        let manager = makeManager()
         await manager.unregisterAll()
         try await Task.sleep(nanoseconds: 100_000_000) // 100ms for CI stability
 
@@ -132,7 +138,7 @@ struct AIServiceManagerIntegrationTests {
 
     @Test("Complex capability query with multiple providers")
     func testComplexCapabilityQuery() async throws {
-        let manager = AIServiceManager.shared
+        let manager = makeManager()
         await manager.unregisterAll()
         try await Task.sleep(nanoseconds: 100_000_000) // 100ms for CI stability
 
@@ -163,7 +169,7 @@ struct AIServiceManagerIntegrationTests {
 
     @Test("Model type query with multiple providers")
     func testModelTypeQuery() async throws {
-        let manager = AIServiceManager.shared
+        let manager = makeManager()
         await manager.unregisterAll()
         try await Task.sleep(nanoseconds: 100_000_000) // 100ms for CI stability
 
@@ -212,7 +218,7 @@ struct AIServiceManagerIntegrationTests {
 
     @Test("Empty capability array returns all providers")
     func testEmptyCapabilityArray() async throws {
-        let manager = AIServiceManager.shared
+        let manager = makeManager()
         await manager.unregisterAll()
         try await Task.sleep(nanoseconds: 100_000_000) // 100ms for CI stability
 
@@ -231,7 +237,7 @@ struct AIServiceManagerIntegrationTests {
 
     @Test("Query for non-existent capability returns empty array")
     func testNonExistentCapabilityQuery() async throws {
-        let manager = AIServiceManager.shared
+        let manager = makeManager()
         await manager.unregisterAll()
         try await Task.sleep(nanoseconds: 100_000_000) // 100ms for CI stability
 
@@ -245,7 +251,7 @@ struct AIServiceManagerIntegrationTests {
 
     @Test("Query for non-existent model type returns empty array")
     func testNonExistentModelTypeQuery() async throws {
-        let manager = AIServiceManager.shared
+        let manager = makeManager()
         await manager.unregisterAll()
         try await Task.sleep(nanoseconds: 100_000_000) // 100ms for CI stability
 
@@ -257,7 +263,7 @@ struct AIServiceManagerIntegrationTests {
 
     @Test("Statistics reflect accurate provider state")
     func testStatisticsAccuracy() async throws {
-        let manager = AIServiceManager.shared
+        let manager = makeManager()
         await manager.unregisterAll()
         try await Task.sleep(nanoseconds: 100_000_000) // 100ms for CI stability
 

--- a/Tests/SwiftHablareTests/Manager/AIServiceManagerPerformanceTests.swift
+++ b/Tests/SwiftHablareTests/Manager/AIServiceManagerPerformanceTests.swift
@@ -10,6 +10,12 @@ import Foundation
 @Suite(.serialized, .tags(.performance))
 struct AIServiceManagerPerformanceTests {
 
+    /// Creates an isolated manager per test to ensure performance measurements
+    /// aren't impacted by shared state from other suites running in parallel.
+    private func makeManager() -> AIServiceManager {
+        AIServiceManager()
+    }
+
     // MARK: - Performance Metrics Output
 
     /// Writes performance metrics in JSON format for GitHub Actions tracking.
@@ -38,7 +44,7 @@ struct AIServiceManagerPerformanceTests {
 
     @Test("Measures concurrent registration performance", .tags(.performance))
     func measureConcurrentRegistration() async throws {
-        let manager = AIServiceManager.shared
+        let manager = makeManager()
         await manager.unregisterAll()
 
         // Wait for cleanup
@@ -89,7 +95,7 @@ struct AIServiceManagerPerformanceTests {
 
     @Test("Measures concurrent query performance", .tags(.performance))
     func measureConcurrentQueries() async throws {
-        let manager = AIServiceManager.shared
+        let manager = makeManager()
         await manager.unregisterAll()
 
         // Register test providers
@@ -139,7 +145,7 @@ struct AIServiceManagerPerformanceTests {
 
     @Test("Measures high load performance with mixed operations", .tags(.performance))
     func measureHighLoadMixedOperations() async throws {
-        let manager = AIServiceManager.shared
+        let manager = makeManager()
         await manager.unregisterAll()
 
         try await Task.sleep(nanoseconds: 50_000_000) // 50ms

--- a/Tests/SwiftHablareTests/Manager/AIServiceManagerTests.swift
+++ b/Tests/SwiftHablareTests/Manager/AIServiceManagerTests.swift
@@ -10,9 +10,7 @@ struct AIServiceManagerTests {
 
     /// Creates a fresh manager instance for isolated testing.
     func createManager() -> AIServiceManager {
-        // Note: Cannot use shared instance for tests as it's persistent
-        // For now, we'll test the shared instance with cleanup
-        return AIServiceManager.shared
+        AIServiceManager()
     }
 
     /// Test model for SwiftData integration.


### PR DESCRIPTION
## Summary
- allow creating isolated AIServiceManager actors for testing purposes
- update AIServiceManager unit, integration, concurrency, and performance tests to use fresh managers per test to avoid parallel interference

## Testing
- Not run (Swift 6.2 toolchain is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68eafe09ec4883218ea61bd59cdd1c1e