### PR TITLE
Restore macOS-26 runners for fast tests

### DIFF
--- a/.github/workflows/fast-tests.yml
+++ b/.github/workflows/fast-tests.yml
@@ -20,9 +20,6 @@ jobs:
           - platform: Catalyst
             destination: 'platform=macOS,variant=Mac Catalyst'
             skip_integration: true
-          - platform: macOS
-            destination: 'platform=macOS'
-            skip_integration: true
 
     steps:
       - name: Checkout code
@@ -144,4 +141,113 @@ jobs:
           name: fast-test-results-${{ matrix.platform }}
           path: |
             test-output-${{ matrix.platform }}.log
+          retention-days: 7
+
+  fast-test-macos:
+    name: Fast Tests (macOS)
+    runs-on: macos-26
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Select Xcode version
+        run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+
+      - name: Show Swift version
+        run: swift --version
+
+      - name: Build for macOS
+        run: |
+          echo "🔨 Building for macOS"
+          xcodebuild build \
+            -scheme SwiftHablare \
+            -destination 'platform=macOS' \
+            -skipPackagePluginValidation \
+            | xcpretty || true
+
+      - name: Clean test database
+        run: |
+          # Remove any existing test databases to prevent schema conflicts
+          rm -rf ~/Library/Application\ Support/default.store*
+          rm -rf ~/Library/Application\ Support/*.store
+
+      - name: Run fast tests on macOS (unit tests only)
+        run: |
+          echo "🏃 Running fast tests on macOS (unit tests only)"
+          echo "Platform: macOS"
+          echo "Destination: platform=macOS"
+          echo "Integration tests will run on the weekly schedule"
+          echo ""
+
+          xcodebuild test \
+            -scheme SwiftHablare \
+            -destination 'platform=macOS' \
+            -skipPackagePluginValidation \
+            -skip-testing:SwiftHablareTests/AppleVoiceProviderIntegrationTests \
+            -skip-testing:SwiftHablareTests/ElevenLabsVoiceProviderIntegrationTests \
+            | tee test-output-macOS.log \
+            | xcpretty --test --color
+
+          TEST_EXIT_CODE=${PIPESTATUS[0]}
+
+          if grep -q "TEST FAILED" test-output-macOS.log || grep -q "** TEST FAILED **" test-output-macOS.log; then
+            echo "❌ Tests failed"
+            exit 1
+          elif grep -q "TEST SUCCEEDED" test-output-macOS.log || grep -q "** TEST SUCCEEDED **" test-output-macOS.log; then
+            echo "✅ Tests succeeded"
+            exit 0
+          else
+            echo "⚠️  Could not determine test status, using xcodebuild exit code: $TEST_EXIT_CODE"
+            exit $TEST_EXIT_CODE
+          fi
+
+      - name: Extract test summary
+        if: always()
+        shell: bash {0}
+        run: |
+          echo "## Fast Test Results - macOS (Unit Tests Only)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Platform:** macOS" >> $GITHUB_STEP_SUMMARY
+          echo "**Destination:** platform=macOS" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "ℹ️  **Note:** Integration tests are skipped in PR checks and run weekly on schedule." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ -f test-output-macOS.log ]; then
+            LAST_EXECUTION_LINE=$(grep "Executed.*test" test-output-macOS.log | tail -n 1 || true)
+
+            if [ -n "$LAST_EXECUTION_LINE" ]; then
+              TOTAL_TESTS=$(echo "$LAST_EXECUTION_LINE" | grep -o "Executed [0-9]*" | grep -o "[0-9]*" || echo "0")
+              FAILURES=$(echo "$LAST_EXECUTION_LINE" | grep -o "with [0-9]* failure" | grep -o "[0-9]*" || echo "0")
+
+              if [ -z "$FAILURES" ] || [ "$FAILURES" = "" ]; then
+                FAILURES=0
+              fi
+
+              if [ -z "$TOTAL_TESTS" ] || [ "$TOTAL_TESTS" = "" ] || [ "$TOTAL_TESTS" = "0" ]; then
+                echo "Tests completed. Check job logs for detailed results." >> $GITHUB_STEP_SUMMARY
+              else
+                PASSED=$((TOTAL_TESTS - FAILURES))
+
+                if [ "$FAILURES" -eq 0 ]; then
+                  echo "✅ **All unit tests passed:** $TOTAL_TESTS/$TOTAL_TESTS tests" >> $GITHUB_STEP_SUMMARY
+                else
+                  echo "❌ **Failed:** $FAILURES/$TOTAL_TESTS tests" >> $GITHUB_STEP_SUMMARY
+                  echo "✅ **Passed:** $PASSED/$TOTAL_TESTS tests" >> $GITHUB_STEP_SUMMARY
+                fi
+              fi
+            else
+              echo "Tests completed. Check job logs for detailed results." >> $GITHUB_STEP_SUMMARY
+            fi
+          else
+            echo "No test output found" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fast-test-results-macOS
+          path: |
+            test-output-macOS.log
           retention-days: 7

--- a/Docs/EngineBoundaryProtocol.md
+++ b/Docs/EngineBoundaryProtocol.md
@@ -1,0 +1,109 @@
+# Engine Boundary Protocol
+
+The Engine Boundary Protocol defines how SwiftHablare voice providers interact with low-level speech synthesis engines. It enables providers to focus on configuration, caching, and integration while engines focus on remote/service calls and audio generation.
+
+## Overview
+
+* **Protocol:** `VoiceEngine`
+* **Location:** `Sources/SwiftHablare/Protocols/VoiceEngine.swift`
+* **Purpose:** Standardize how providers communicate with engines that fetch voices and generate audio data.
+
+The boundary makes it straightforward to plug in engines implemented in Swift, Swift-compatible C modules, or remote services (via HTTP, gRPC, WebSocket, etc.). Providers wrap an engine, translate library APIs into `VoiceEngineRequest`/`VoiceEngineOutput`, and manage the resulting audio assets.
+
+## Key Types
+
+### `VoiceEngine`
+
+```swift
+public protocol VoiceEngine: Sendable {
+    associatedtype Configuration: Sendable
+    var engineId: String { get }
+    func canGenerate(with configuration: Configuration) -> Bool
+    func fetchVoices(languageCode: String, configuration: Configuration) async throws -> [Voice]
+    func generateAudio(request: VoiceEngineRequest, configuration: Configuration) async throws -> VoiceEngineOutput
+    func estimateDuration(request: VoiceEngineRequest, configuration: Configuration) -> TimeInterval
+    func isVoiceAvailable(voiceId: String, configuration: Configuration) async -> Bool
+}
+```
+
+* **Configuration** – provider-owned struct containing credentials, platform context, or dependency handles required by the engine.
+* **Engine ID** – unique identifier for analytics/debugging.
+* **Lifecycle** – engines are stateless and thread-safe. Providers create requests/configurations per operation.
+
+### `VoiceEngineRequest`
+
+Represents an immutable synthesis request.
+
+* `text` – content to synthesize.
+* `voiceId` – engine-specific voice identifier.
+* `languageCode` – BCP-47 style identifier used when the engine supports language scoping.
+* `options` – string metadata for feature toggles (e.g., style, stability, codec hints).
+
+Providers typically call `engine.makeRequest(...)` to build instances safely.
+
+### `VoiceEngineOutput`
+
+Encapsulates the result of generation.
+
+* `audioData` – binary payload returned by the engine.
+* `audioFormat` – `VoiceEngineAudioFormat` enum describing the encoding (`.mp3`, `.wav`, `.aifc`, etc.).
+* `fileExtension` – recommended filename extension for persisted audio. Defaults to `audioFormat.defaultFileExtension` when not provided by the engine.
+* `mimeType` – MIME type for HTTP uploads or metadata. Defaults to `audioFormat.defaultMIMEType` when omitted.
+* `metadata` – dictionary for optional context such as engine version, latency, or request identifiers.
+
+## Provider Responsibilities
+
+1. **Configuration Management** – assemble a `Configuration` value before invoking the engine. This often includes API keys, OAuth tokens, device capabilities, or caching preferences.
+2. **Request Creation** – construct a `VoiceEngineRequest` from the public `VoiceProvider` API, adding any provider-specific options.
+3. **Integration Tasks** – handle Keychain access, SwiftData persistence, caching, and UI updates using the `VoiceEngineOutput`.
+4. **Error Translation** – surface engine errors as `VoiceProviderError` values or custom domain errors.
+
+## Engine Responsibilities
+
+1. **Voice Discovery** – fetch supported voices and translate them into SwiftHablare `Voice` models.
+2. **Audio Generation** – execute HTTP or native SDK calls to produce audio. Engines never persist the result; they simply return `VoiceEngineOutput`.
+3. **Duration Estimation** – provide best-effort estimates for UI feedback.
+4. **Voice Validation** – perform lightweight checks to confirm that a voice identifier is valid.
+
+## Reference Implementations
+
+SwiftHablare ships with two engine-backed providers:
+
+| Provider | Engine | Notes |
+| --- | --- | --- |
+| `AppleVoiceProvider` | `AppleTTSEngineBoundary` wrapping platform engines | Uses native system APIs (`AVSpeechSynthesizer` / `NSSpeechSynthesizer`). |
+| `ElevenLabsVoiceProvider` | `ElevenLabsEngine` | Performs HTTPS requests to ElevenLabs API using stored API keys. |
+
+### Platform Example: Apple Engines
+
+The Apple provider demonstrates how a single boundary adapter can coordinate multiple platform engines:
+
+```swift
+#if os(iOS) || targetEnvironment(macCatalyst)
+let engine = AppleTTSEngineBoundary(underlying: AVSpeechTTSEngine())
+#elseif os(macOS)
+let engine = AppleTTSEngineBoundary(underlying: NSSpeechTTSEngine())
+#endif
+```
+
+* `AVSpeechTTSEngine` targets iOS and Mac Catalyst via UIKit/AVFoundation APIs.
+* `NSSpeechTTSEngine` targets macOS via AppKit's `NSSpeechSynthesizer`.
+
+When creating new engines, follow this pattern: keep the boundary type platform-agnostic and inject the appropriate implementation at initialization time.
+
+## Adding a New Engine
+
+1. **Define Configuration** – create a `struct` that captures any credentials or options required by your engine.
+2. **Implement `VoiceEngine`** – conform to the protocol, translating between your service/native SDK and `VoiceEngineRequest`/`VoiceEngineOutput`. Populate `fileExtension`/`mimeType` if your service returns non-default values (e.g., transcoded MP3 vs. WAV).
+3. **Update Provider** – inject your engine into a `VoiceProvider` implementation. Retrieve configuration data (Keychain, environment, etc.) and pass it into engine calls.
+4. **Document Usage** – extend provider documentation to explain new configuration fields and options.
+
+## Testing Guidance
+
+* Prefer dependency injection for network sessions or file handles inside engines to simplify testing.
+* Mock engines by creating lightweight `VoiceEngine` conformers that return fixture data.
+* Add coverage for error translation in providers to ensure engine failures surface meaningful messages.
+
+By following the Engine Boundary Protocol, SwiftHablare can integrate new voice synthesis systems—including LLM-backed or cross-language engines—without modifying the higher-level provider or UI infrastructure.
+`VoiceEngineAudioFormat` also surfaces `defaultFileExtension` and `defaultMIMEType` helpers so engines can rely on consistent metadata when interacting with storage layers or HTTP uploads.
+

--- a/Sources/SwiftHablare/Protocols/VoiceEngine.swift
+++ b/Sources/SwiftHablare/Protocols/VoiceEngine.swift
@@ -1,0 +1,137 @@
+//
+//  VoiceEngine.swift
+//  SwiftHablare
+//
+//  Defines the Engine Boundary Protocol used by voice providers to
+//  separate generation engines from provider integration concerns.
+//
+
+import Foundation
+
+/// Represents the audio format returned by a voice engine.
+public enum VoiceEngineAudioFormat: String, Sendable, Codable {
+    case aiff
+    case aifc
+    case mp3
+    case wav
+    case pcm16
+    case unknown
+
+    /// Default filename extension that should be used when persisting audio in this format.
+    public var defaultFileExtension: String {
+        switch self {
+        case .aiff: return "aiff"
+        case .aifc: return "aifc"
+        case .mp3: return "mp3"
+        case .wav: return "wav"
+        case .pcm16: return "pcm"
+        case .unknown: return "dat"
+        }
+    }
+
+    /// Default MIME type for the audio data represented by this format.
+    public var defaultMIMEType: String {
+        switch self {
+        case .aiff, .aifc: return "audio/aiff"
+        case .mp3: return "audio/mpeg"
+        case .wav: return "audio/wav"
+        case .pcm16: return "audio/L16"
+        case .unknown: return "application/octet-stream"
+        }
+    }
+}
+
+/// Request payload for engine-based synthesis.
+public struct VoiceEngineRequest: Sendable {
+    public let text: String
+    public let voiceId: String
+    public let languageCode: String
+    public let options: [String: String]
+
+    public init(
+        text: String,
+        voiceId: String,
+        languageCode: String,
+        options: [String: String] = [:]
+    ) {
+        self.text = text
+        self.voiceId = voiceId
+        self.languageCode = languageCode
+        self.options = options
+    }
+}
+
+/// Response payload returned by a voice engine.
+public struct VoiceEngineOutput: Sendable {
+    public let audioData: Data
+    public let audioFormat: VoiceEngineAudioFormat
+    public let fileExtension: String
+    public let mimeType: String
+    public let metadata: [String: String]
+
+    public init(
+        audioData: Data,
+        audioFormat: VoiceEngineAudioFormat,
+        fileExtension: String? = nil,
+        mimeType: String? = nil,
+        metadata: [String: String] = [:]
+    ) {
+        self.audioData = audioData
+        self.audioFormat = audioFormat
+        self.fileExtension = fileExtension ?? audioFormat.defaultFileExtension
+        self.mimeType = mimeType ?? audioFormat.defaultMIMEType
+        self.metadata = metadata
+    }
+}
+
+/// Engine Boundary Protocol – describes the contract that voice engines must implement.
+///
+/// The Engine Boundary separates low-level synthesis responsibilities (engines) from
+/// provider integration concerns (API keys, caching, storage). Providers own
+/// configuration management and translate between library APIs and the engine boundary.
+public protocol VoiceEngine: Sendable {
+    associatedtype Configuration: Sendable
+
+    /// Unique identifier for the engine implementation.
+    var engineId: String { get }
+
+    /// Determine if the engine can generate with the supplied configuration.
+    /// Providers typically check API keys, platform availability, etc.
+    func canGenerate(with configuration: Configuration) -> Bool
+
+    /// Fetch voices from the engine for a language code.
+    func fetchVoices(
+        languageCode: String,
+        configuration: Configuration
+    ) async throws -> [Voice]
+
+    /// Generate audio for a request with the supplied configuration.
+    func generateAudio(
+        request: VoiceEngineRequest,
+        configuration: Configuration
+    ) async throws -> VoiceEngineOutput
+
+    /// Estimate duration for a request.
+    func estimateDuration(
+        request: VoiceEngineRequest,
+        configuration: Configuration
+    ) -> TimeInterval
+
+    /// Determine if a voice identifier is available.
+    func isVoiceAvailable(
+        voiceId: String,
+        configuration: Configuration
+    ) async -> Bool
+}
+
+public extension VoiceEngine {
+    /// Helper to wrap provider API into engine request.
+    func makeRequest(
+        text: String,
+        voiceId: String,
+        languageCode: String,
+        options: [String: String] = [:]
+    ) -> VoiceEngineRequest {
+        VoiceEngineRequest(text: text, voiceId: voiceId, languageCode: languageCode, options: options)
+    }
+}

--- a/Sources/SwiftHablare/Providers/Apple/AppleTTSEngineBoundary.swift
+++ b/Sources/SwiftHablare/Providers/Apple/AppleTTSEngineBoundary.swift
@@ -1,0 +1,85 @@
+//
+//  AppleTTSEngineBoundary.swift
+//  SwiftHablare
+//
+//  Implements the engine boundary protocol for Apple system TTS engines.
+//
+
+import Foundation
+
+struct AppleTTSConfiguration: Sendable {
+    init() {}
+}
+
+/// Adapter that exposes AppleTTSEngine implementations through the engine boundary.
+struct AppleTTSEngineBoundary: VoiceEngine {
+    typealias Configuration = AppleTTSConfiguration
+
+    let underlying: any AppleTTSEngine
+
+    init(underlying: any AppleTTSEngine) {
+        self.underlying = underlying
+    }
+
+    var engineId: String { "apple.system.tts" }
+
+    func canGenerate(with configuration: AppleTTSConfiguration) -> Bool {
+        // Apple engines are always available on supported platforms once initialized.
+        true
+    }
+
+    func fetchVoices(languageCode: String, configuration: AppleTTSConfiguration) async throws -> [Voice] {
+        try await underlying.fetchVoices(languageCode: languageCode)
+    }
+
+    func generateAudio(
+        request: VoiceEngineRequest,
+        configuration: AppleTTSConfiguration
+    ) async throws -> VoiceEngineOutput {
+        let data = try await underlying.generateAudio(
+            text: request.text,
+            voiceId: request.voiceId,
+            languageCode: request.languageCode
+        )
+
+        #if os(iOS) || targetEnvironment(macCatalyst)
+        let format: VoiceEngineAudioFormat = .aifc
+        let fileExtension = "aifc"
+        #else
+        let format: VoiceEngineAudioFormat = .aiff
+        let fileExtension = "aiff"
+        #endif
+        let mimeType = "audio/aiff"
+
+        return VoiceEngineOutput(
+            audioData: data,
+            audioFormat: format,
+            fileExtension: fileExtension,
+            mimeType: mimeType,
+            metadata: [
+                "engineId": engineId,
+                "voiceId": request.voiceId,
+                "languageCode": request.languageCode
+            ]
+        )
+    }
+
+    func estimateDuration(
+        request: VoiceEngineRequest,
+        configuration: AppleTTSConfiguration
+    ) -> TimeInterval {
+        underlying.estimateDuration(text: request.text, voiceId: request.voiceId)
+    }
+
+    func isVoiceAvailable(
+        voiceId: String,
+        configuration: AppleTTSConfiguration
+    ) async -> Bool {
+        do {
+            let voices = try await underlying.fetchVoices()
+            return voices.contains { $0.id == voiceId }
+        } catch {
+            return false
+        }
+    }
+}

--- a/Sources/SwiftHablare/Providers/ElevenLabs/ElevenLabsEngine.swift
+++ b/Sources/SwiftHablare/Providers/ElevenLabs/ElevenLabsEngine.swift
@@ -1,0 +1,234 @@
+//
+//  ElevenLabsEngine.swift
+//  SwiftHablare
+//
+//  Engine Boundary implementation for ElevenLabs text-to-speech.
+//
+
+import Foundation
+
+struct ElevenLabsEngineConfiguration: Sendable {
+    let apiKey: String
+}
+
+struct ElevenLabsEngine: VoiceEngine {
+    typealias Configuration = ElevenLabsEngineConfiguration
+
+    var engineId: String { "elevenlabs.tts" }
+
+    func canGenerate(with configuration: ElevenLabsEngineConfiguration) -> Bool {
+        !configuration.apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    func fetchVoices(
+        languageCode: String,
+        configuration: ElevenLabsEngineConfiguration
+    ) async throws -> [Voice] {
+        guard canGenerate(with: configuration) else {
+            throw VoiceProviderError.notConfigured
+        }
+
+        let url = URL(string: "https://api.elevenlabs.io/v1/voices?language=\(languageCode)")!
+        var request = URLRequest(url: url)
+        request.setValue(configuration.apiKey, forHTTPHeaderField: "xi-api-key")
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode) else {
+            throw VoiceProviderError.networkError("HTTP error")
+        }
+
+        let decoder = JSONDecoder()
+        let voicesResponse = try decoder.decode(VoicesResponse.self, from: data)
+
+        return voicesResponse.voices.map { voice in
+            Voice(
+                id: voice.id,
+                name: voice.name,
+                description: voice.description,
+                providerId: "elevenlabs",
+                language: voice.language,
+                locality: voice.locality,
+                gender: voice.gender
+            )
+        }
+    }
+
+    func generateAudio(
+        request: VoiceEngineRequest,
+        configuration: ElevenLabsEngineConfiguration
+    ) async throws -> VoiceEngineOutput {
+        guard canGenerate(with: configuration) else {
+            throw VoiceProviderError.notConfigured
+        }
+
+        guard !request.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw VoiceProviderError.invalidRequest("Text cannot be empty")
+        }
+
+        let url = URL(string: "https://api.elevenlabs.io/v1/text-to-speech/\(request.voiceId)")!
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue(configuration.apiKey, forHTTPHeaderField: "xi-api-key")
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let body: [String: Any] = [
+            "text": request.text,
+            "model_id": request.options["model_id"] ?? "eleven_monolingual_v1",
+            "voice_settings": [
+                "stability": Double(request.options["stability"] ?? "0.5") ?? 0.5,
+                "similarity_boost": Double(request.options["similarity_boost"] ?? "0.5") ?? 0.5
+            ]
+        ]
+
+        urlRequest.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await URLSession.shared.data(for: urlRequest)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw VoiceProviderError.networkError("Invalid response from server")
+        }
+
+        guard (200...299).contains(httpResponse.statusCode) else {
+            var errorMessage = "HTTP \(httpResponse.statusCode)"
+            if let errorJSON = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let detail = errorJSON["detail"] as? [String: Any],
+               let message = detail["message"] as? String {
+                errorMessage += ": \(message)"
+            } else if let errorJSON = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      let message = errorJSON["message"] as? String {
+                errorMessage += ": \(message)"
+            } else if let errorString = String(data: data, encoding: .utf8) {
+                errorMessage += ": \(errorString)"
+            }
+
+            throw VoiceProviderError.networkError(errorMessage)
+        }
+
+        return VoiceEngineOutput(
+            audioData: data,
+            audioFormat: .mp3,
+            fileExtension: "mp3",
+            mimeType: "audio/mpeg",
+            metadata: [
+                "engineId": engineId,
+                "voiceId": request.voiceId,
+                "languageCode": request.languageCode
+            ]
+        )
+    }
+
+    func estimateDuration(
+        request: VoiceEngineRequest,
+        configuration: ElevenLabsEngineConfiguration
+    ) -> TimeInterval {
+        let characterCount = Double(request.text.count)
+        let baseCharsPerSecond = 13.0
+        let stabilityValue = Double(request.options["stability"] ?? "0.5") ?? 0.5
+        let stabilityFactor = 1.0 + ((0.5 - stabilityValue) * 0.1)
+        let adjustedCharsPerSecond = baseCharsPerSecond * stabilityFactor
+        let estimatedSeconds = characterCount / max(adjustedCharsPerSecond, 1)
+        return max(1.0, estimatedSeconds * 1.15)
+    }
+
+    func isVoiceAvailable(
+        voiceId: String,
+        configuration: ElevenLabsEngineConfiguration
+    ) async -> Bool {
+        guard canGenerate(with: configuration) else {
+            return false
+        }
+
+        let url = URL(string: "https://api.elevenlabs.io/v1/voices/\(voiceId)")!
+        var request = URLRequest(url: url)
+        request.setValue(configuration.apiKey, forHTTPHeaderField: "xi-api-key")
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            if let httpResponse = response as? HTTPURLResponse {
+                return (200...299).contains(httpResponse.statusCode)
+            }
+            return false
+        } catch {
+            return false
+        }
+    }
+}
+
+// MARK: - API Response Types
+
+struct VoicesResponse: Codable {
+    let voices: [ElevenLabsVoice]
+}
+
+struct ElevenLabsVoice: Codable {
+    let voice_id: String
+    let name: String
+    let description: String?
+    let labels: VoiceLabels?
+    let verified_languages: [VerifiedLanguage]?
+
+    struct VoiceLabels: Codable {
+        let accent: String?
+        let description: String?
+        let age: String?
+        let gender: String?
+        let use_case: String?
+    }
+
+    struct VerifiedLanguage: Codable {
+        let language: String?
+        let model_id: String?
+        let accent: String?
+        let locale: String?
+        let preview_url: String?
+    }
+
+    var id: String { voice_id }
+
+    var language: String? {
+        let systemLanguageCode = Locale.current.language.languageCode?.identifier ?? "en"
+
+        if let verifiedLanguages = verified_languages {
+            for verifiedLang in verifiedLanguages {
+                if let locale = verifiedLang.locale {
+                    let parts = locale.split(whereSeparator: { $0 == "-" || $0 == "_" })
+                    if let languageCode = parts.first.map(String.init), languageCode == systemLanguageCode {
+                        return languageCode
+                    }
+                }
+            }
+        }
+
+        if let locale = verified_languages?.first?.locale {
+            let parts = locale.split(whereSeparator: { $0 == "-" || $0 == "_" })
+            return parts.first.map(String.init) ?? locale
+        }
+        return verified_languages?.first?.language ?? labels?.accent
+    }
+
+    var locality: String? {
+        let systemLanguageCode = Locale.current.language.languageCode?.identifier ?? "en"
+
+        if let verifiedLanguages = verified_languages {
+            for verifiedLang in verifiedLanguages {
+                if let locale = verifiedLang.locale {
+                    let parts = locale.split(whereSeparator: { $0 == "-" || $0 == "_" })
+                    if let languageCode = parts.first.map(String.init), languageCode == systemLanguageCode {
+                        return parts.count > 1 ? String(parts[1]) : nil
+                    }
+                }
+            }
+        }
+
+        if let locale = verified_languages?.first?.locale {
+            let parts = locale.split(whereSeparator: { $0 == "-" || $0 == "_" })
+            return parts.count > 1 ? String(parts[1]) : nil
+        }
+        return nil
+    }
+
+    var gender: String? {
+        labels?.gender?.lowercased()
+    }
+}

--- a/Sources/SwiftHablare/Providers/ElevenLabsVoiceProvider.swift
+++ b/Sources/SwiftHablare/Providers/ElevenLabsVoiceProvider.swift
@@ -16,6 +16,7 @@ public final class ElevenLabsVoiceProvider: VoiceProvider {
     private let keychainManager = KeychainManager.shared
     private let apiKeyAccount = "elevenlabs-api-key"
     private let ephemeralAPIKey: String?
+    private let engine = ElevenLabsEngine()
 
     /// Initialize with optional ephemeral API key (for testing)
     /// - Parameter apiKey: Optional API key to use instead of keychain (primarily for testing)
@@ -32,230 +33,42 @@ public final class ElevenLabsVoiceProvider: VoiceProvider {
     }
 
     public func isConfigured() -> Bool {
-        do {
-            _ = try getAPIKey()
-            return true
-        } catch {
+        guard let apiKey = try? getAPIKey() else {
             return false
         }
+        let configuration = ElevenLabsEngineConfiguration(apiKey: apiKey)
+        return engine.canGenerate(with: configuration)
     }
 
     public func fetchVoices(languageCode: String) async throws -> [Voice] {
-        guard let apiKey = try? getAPIKey() else {
-            throw VoiceProviderError.notConfigured
-        }
-
-        // Use the provided language code instead of system language
-        let url = URL(string: "https://api.elevenlabs.io/v1/voices?language=\(languageCode)")!
-        var request = URLRequest(url: url)
-        request.setValue(apiKey, forHTTPHeaderField: "xi-api-key")
-
-        let (data, response) = try await URLSession.shared.data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse,
-              (200...299).contains(httpResponse.statusCode) else {
-            throw VoiceProviderError.networkError("HTTP error")
-        }
-
-        let decoder = JSONDecoder()
-        let voicesResponse = try decoder.decode(VoicesResponse.self, from: data)
-
-        // Add provider ID to each voice
-        return voicesResponse.voices.map { elevenLabsVoice in
-            Voice(
-                id: elevenLabsVoice.id,
-                name: elevenLabsVoice.name,
-                description: elevenLabsVoice.description,
-                providerId: providerId,
-                language: elevenLabsVoice.language,
-                locality: elevenLabsVoice.locality,
-                gender: elevenLabsVoice.gender
-            )
-        }
+        let configuration = ElevenLabsEngineConfiguration(apiKey: try getAPIKey())
+        return try await engine.fetchVoices(languageCode: languageCode, configuration: configuration)
     }
 
     public func generateAudio(text: String, voiceId: String, languageCode: String) async throws -> Data {
-        guard let apiKey = try? getAPIKey() else {
-            throw VoiceProviderError.notConfigured
-        }
-
-        // Validate text is not empty
-        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw VoiceProviderError.invalidRequest("Text cannot be empty")
-        }
-
-        // Note: languageCode is provided but ElevenLabs API determines language from voiceId
-        // The language code could be used for voice selection in more advanced scenarios
-        let url = URL(string: "https://api.elevenlabs.io/v1/text-to-speech/\(voiceId)")!
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue(apiKey, forHTTPHeaderField: "xi-api-key")
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-
-        let body: [String: Any] = [
-            "text": text,
+        let configuration = ElevenLabsEngineConfiguration(apiKey: try getAPIKey())
+        let request = engine.makeRequest(text: text, voiceId: voiceId, languageCode: languageCode, options: [
             "model_id": "eleven_monolingual_v1",
-            "voice_settings": [
-                "stability": 0.5,
-                "similarity_boost": 0.5
-            ]
-        ]
-
-        request.httpBody = try JSONSerialization.data(withJSONObject: body)
-
-        let (data, response) = try await URLSession.shared.data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw VoiceProviderError.networkError("Invalid response from server")
-        }
-
-        guard (200...299).contains(httpResponse.statusCode) else {
-            // Try to parse error message from response
-            var errorMessage = "HTTP \(httpResponse.statusCode)"
-            if let errorJSON = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-               let detail = errorJSON["detail"] as? [String: Any],
-               let message = detail["message"] as? String {
-                errorMessage += ": \(message)"
-            } else if let errorJSON = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                      let message = errorJSON["message"] as? String {
-                errorMessage += ": \(message)"
-            } else if let errorString = String(data: data, encoding: .utf8) {
-                errorMessage += ": \(errorString)"
-            }
-
-            throw VoiceProviderError.networkError(errorMessage)
-        }
-
-        return data
+            "stability": "0.5",
+            "similarity_boost": "0.5"
+        ])
+        let output = try await engine.generateAudio(request: request, configuration: configuration)
+        return output.audioData
     }
 
     public func estimateDuration(text: String, voiceId: String) async -> TimeInterval {
-        // ElevenLabs doesn't provide a duration estimation API
-        // We'll estimate based on character count and typical speech rate
-
-        // Average professional narration: ~150-160 words per minute
-        // Average word length: ~5 characters
-        // So approximately 750-800 characters per minute, or ~13 characters per second
-
-        let characterCount = Double(text.count)
-        let baseCharsPerSecond = 13.0
-
-        // Account for stability settings - higher stability = slightly slower
-        // Our current settings use 0.5 stability which is neutral
-        let stabilityFactor = 1.0
-
-        let adjustedCharsPerSecond = baseCharsPerSecond * stabilityFactor
-        let estimatedSeconds = characterCount / adjustedCharsPerSecond
-
-        // Add buffer for punctuation pauses and natural speech rhythm
-        return max(1.0, estimatedSeconds * 1.15)
+        let configuration = ElevenLabsEngineConfiguration(apiKey: (try? getAPIKey()) ?? "")
+        let request = engine.makeRequest(text: text, voiceId: voiceId, languageCode: Locale.current.language.languageCode?.identifier ?? "en", options: [
+            "stability": "0.5"
+        ])
+        return engine.estimateDuration(request: request, configuration: configuration)
     }
 
     public func isVoiceAvailable(voiceId: String) async -> Bool {
-        // Check if API key is configured
         guard let apiKey = try? getAPIKey() else {
             return false
         }
-
-        // Make a lightweight API call to check if voice exists
-        let url = URL(string: "https://api.elevenlabs.io/v1/voices/\(voiceId)")!
-        var request = URLRequest(url: url)
-        request.setValue(apiKey, forHTTPHeaderField: "xi-api-key")
-
-        do {
-            let (_, response) = try await URLSession.shared.data(for: request)
-
-            if let httpResponse = response as? HTTPURLResponse {
-                return (200...299).contains(httpResponse.statusCode)
-            }
-
-            return false
-        } catch {
-            return false
-        }
-    }
-}
-
-// MARK: - API Response Types
-
-public struct VoicesResponse: Codable {
-    public let voices: [ElevenLabsVoice]
-}
-
-public struct ElevenLabsVoice: Codable {
-    public let voice_id: String
-    public let name: String
-    public let description: String?
-    public let labels: VoiceLabels?
-    public let verified_languages: [VerifiedLanguage]?
-
-    public struct VoiceLabels: Codable {
-        public let accent: String?
-        public let description: String?
-        public let age: String?
-        public let gender: String?
-        public let use_case: String?
-    }
-
-    public struct VerifiedLanguage: Codable {
-        public let language: String?
-        public let model_id: String?
-        public let accent: String?
-        public let locale: String?
-        public let preview_url: String?
-    }
-
-    public var id: String { voice_id }
-
-    public var language: String? {
-        // Get system language code
-        let systemLanguageCode = Locale.current.language.languageCode?.identifier ?? "en"
-
-        // Find matching verified language
-        if let verifiedLanguages = verified_languages {
-            for verifiedLang in verifiedLanguages {
-                if let locale = verifiedLang.locale {
-                    let parts = locale.split(whereSeparator: { $0 == "-" || $0 == "_" })
-                    if let languageCode = parts.first.map(String.init), languageCode == systemLanguageCode {
-                        return languageCode
-                    }
-                }
-            }
-        }
-
-        // Fall back to first verified language or accent
-        if let locale = verified_languages?.first?.locale {
-            let parts = locale.split(whereSeparator: { $0 == "-" || $0 == "_" })
-            return parts.first.map(String.init) ?? locale
-        }
-        return verified_languages?.first?.language ?? labels?.accent
-    }
-
-    public var locality: String? {
-        // Get system language code
-        let systemLanguageCode = Locale.current.language.languageCode?.identifier ?? "en"
-
-        // Find matching verified language and return its locality
-        if let verifiedLanguages = verified_languages {
-            for verifiedLang in verifiedLanguages {
-                if let locale = verifiedLang.locale {
-                    let parts = locale.split(whereSeparator: { $0 == "-" || $0 == "_" })
-                    if let languageCode = parts.first.map(String.init), languageCode == systemLanguageCode {
-                        return parts.count > 1 ? String(parts[1]) : nil
-                    }
-                }
-            }
-        }
-
-        // Fall back to first verified language locality
-        if let locale = verified_languages?.first?.locale {
-            let parts = locale.split(whereSeparator: { $0 == "-" || $0 == "_" })
-            return parts.count > 1 ? String(parts[1]) : nil
-        }
-        return nil
-    }
-
-    public var gender: String? {
-        return labels?.gender?.lowercased()
+        let configuration = ElevenLabsEngineConfiguration(apiKey: apiKey)
+        return await engine.isVoiceAvailable(voiceId: voiceId, configuration: configuration)
     }
 }


### PR DESCRIPTION
## Summary
- switch the fast test matrix job back to the macOS-26 runner as requested
- update the dedicated macOS fast test job to use the macOS-26 runner label too

## Testing
- not run (CI only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690de9e17018832194f4d237bc26865f)