### PR TITLE
Fix version-bump workflow PR title format

### DIFF
--- a/.github/workflows/version-bump-on-release.yml
+++ b/.github/workflows/version-bump-on-release.yml
@@ -97,7 +97,7 @@ jobs:
           gh pr create \
             --base main \
             --head development \
-            --title "Version ${{ steps.new-version.outputs.new }} => ${{ steps.current-version.outputs.current }}" \
+            --title "${{ steps.new-version.outputs.new }} => ${{ steps.current-version.outputs.current }}" \
             --body "## Automated Version Bump
 
           This PR contains an automated version bump following the publication of release **${{ github.event.release.tag_name }}**.


### PR DESCRIPTION
## Fix Version-Bump Workflow PR Title Format

This PR updates the version-bump-on-release workflow to match SwiftCompartido's exact PR title format.

### Changes

**Before:**
```
--title "Version ${{ steps.new-version.outputs.new }} => ${{ steps.current-version.outputs.current }}"
```

**After:**
```
--title "${{ steps.new-version.outputs.new }} => ${{ steps.current-version.outputs.current }}"
```

### Reason

SwiftCompartido's version-bump workflow uses the format `"NEW_VERSION => PREVIOUS_VERSION"` without the "Version" prefix. This update ensures consistency across repositories.

**Example PR Titles:**
- ❌ Before: "Version 3.7.0 => 3.6.0"
- ✅ After: "3.7.0 => 3.6.0"

### Files Changed

- `.github/workflows/version-bump-on-release.yml` - Updated PR title format (1 line)

### Testing

The workflow will create PRs with the correct format on the next release.

### References

- SwiftCompartido workflow: https://github.com/intrusive-memory/SwiftCompartido/blob/main/.github/workflows/version-bump-on-release.yml#L106

🤖 Quick fix for consistency