### PR TITLE
Release v6.2.0: raise SwiftProyecto floor to 4.x

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,14 @@
+---
+type: reference
+---
+
 # AGENTS.md
 
 This file provides comprehensive documentation for AI agents working with the SwiftHablaré codebase.
 
 ## Quick Reference
 
-- **Current Version**: 6.1.1-dev (check `SwiftHablare.swift` for actual version string)
+- **Current Version**: 6.2.0 (check `SwiftHablare.swift` for actual version string)
 - **Swift Version**: 6.2+
 - **Minimum Deployments**: iOS 26+, macOS 26+
 - **Test Suite**: 229+ passing tests (SwiftHablare)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides comprehensive documentation for AI agents working with the Sw
 
 ## Quick Reference
 
-- **Current Version**: 6.1.1 (check `SwiftHablare.swift` for actual version string)
+- **Current Version**: 6.1.1-dev (check `SwiftHablare.swift` for actual version string)
 - **Swift Version**: 6.2+
 - **Minimum Deployments**: iOS 26+, macOS 26+
 - **Test Suite**: 229+ passing tests (SwiftHablare)

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,44 @@
 // swift-tools-version: 6.2
 
+import Foundation
 import PackageDescription
+
+// In CI we always pin to released remotes. Locally, prefer a sibling checkout
+// at ../<name> if present so in-flight changes can be exercised end-to-end
+// without publishing a release. Falls back to the remote pin if the sibling
+// directory is missing, so fresh clones still build.
+//
+// When this manifest is evaluated as a transitive dependency inside Xcode's
+// `SourcePackages/checkouts/` or SwiftPM's `.build/checkouts/`, every other
+// dependency lives as a sibling in the same directory. Treating those as
+// in-development local paths produces conflicting package identities, so we
+// must skip the sibling shortcut in that context.
+let manifestDir = (#filePath as NSString).deletingLastPathComponent
+let isSPMCheckout =
+  manifestDir.contains("/SourcePackages/checkouts/")
+  || manifestDir.contains("/.build/checkouts/")
+let isCI = ProcessInfo.processInfo.environment["CI"] == "true"
+let useLocalSiblings = !isCI && !isSPMCheckout
+
+func sibling(_ name: String, remote: String, from version: Version) -> Package.Dependency {
+  let localPath = "../\(name)"
+  if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
+    return .package(path: localPath)
+  }
+  return .package(url: remote, .upToNextMajor(from: version))
+}
+
+/// Same sibling-priority pattern as ``sibling(_:remote:from:)`` but pins to a
+/// remote branch when no local sibling exists. Use only when a temporary
+/// pre-release dependency on a feature branch is required; switch back to the
+/// version-pinned ``sibling(_:remote:from:)`` once the upstream tags a release.
+func sibling(_ name: String, remote: String, branch: String) -> Package.Dependency {
+  let localPath = "../\(name)"
+  if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
+    return .package(path: localPath)
+  }
+  return .package(url: remote, branch: branch)
+}
 
 let package = Package(
   name: "SwiftHablare",
@@ -15,12 +53,18 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(
-      url: "https://github.com/intrusive-memory/SwiftFijos.git", .upToNextMajor(from: "1.4.1")),
-    .package(
-      url: "https://github.com/intrusive-memory/SwiftCompartido.git", .upToNextMajor(from: "7.0.4")),
-    .package(
-      url: "https://github.com/intrusive-memory/SwiftProyecto.git", .upToNextMajor(from: "3.5.0")),
+    sibling(
+      "SwiftFijos",
+      remote: "https://github.com/intrusive-memory/SwiftFijos.git",
+      from: "1.4.1"),
+    sibling(
+      "SwiftCompartido",
+      remote: "https://github.com/intrusive-memory/SwiftCompartido.git",
+      from: "7.0.4"),
+    sibling(
+      "SwiftProyecto",
+      remote: "https://github.com/intrusive-memory/SwiftProyecto.git",
+      from: "3.5.0"),
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,44 +1,6 @@
 // swift-tools-version: 6.2
 
-import Foundation
 import PackageDescription
-
-// In CI we always pin to released remotes. Locally, prefer a sibling checkout
-// at ../<name> if present so in-flight changes can be exercised end-to-end
-// without publishing a release. Falls back to the remote pin if the sibling
-// directory is missing, so fresh clones still build.
-//
-// When this manifest is evaluated as a transitive dependency inside Xcode's
-// `SourcePackages/checkouts/` or SwiftPM's `.build/checkouts/`, every other
-// dependency lives as a sibling in the same directory. Treating those as
-// in-development local paths produces conflicting package identities, so we
-// must skip the sibling shortcut in that context.
-let manifestDir = (#filePath as NSString).deletingLastPathComponent
-let isSPMCheckout =
-  manifestDir.contains("/SourcePackages/checkouts/")
-  || manifestDir.contains("/.build/checkouts/")
-let isCI = ProcessInfo.processInfo.environment["CI"] == "true"
-let useLocalSiblings = !isCI && !isSPMCheckout
-
-func sibling(_ name: String, remote: String, from version: Version) -> Package.Dependency {
-  let localPath = "../\(name)"
-  if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
-    return .package(path: localPath)
-  }
-  return .package(url: remote, .upToNextMajor(from: version))
-}
-
-/// Same sibling-priority pattern as ``sibling(_:remote:from:)`` but pins to a
-/// remote branch when no local sibling exists. Use only when a temporary
-/// pre-release dependency on a feature branch is required; switch back to the
-/// version-pinned ``sibling(_:remote:from:)`` once the upstream tags a release.
-func sibling(_ name: String, remote: String, branch: String) -> Package.Dependency {
-  let localPath = "../\(name)"
-  if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
-    return .package(path: localPath)
-  }
-  return .package(url: remote, branch: branch)
-}
 
 let package = Package(
   name: "SwiftHablare",
@@ -53,18 +15,12 @@ let package = Package(
     )
   ],
   dependencies: [
-    sibling(
-      "SwiftFijos",
-      remote: "https://github.com/intrusive-memory/SwiftFijos.git",
-      from: "1.4.1"),
-    sibling(
-      "SwiftCompartido",
-      remote: "https://github.com/intrusive-memory/SwiftCompartido.git",
-      from: "7.0.4"),
-    sibling(
-      "SwiftProyecto",
-      remote: "https://github.com/intrusive-memory/SwiftProyecto.git",
-      from: "4.0.0"),
+    .package(
+      url: "https://github.com/intrusive-memory/SwiftFijos.git", .upToNextMajor(from: "1.4.1")),
+    .package(
+      url: "https://github.com/intrusive-memory/SwiftCompartido.git", .upToNextMajor(from: "7.0.4")),
+    .package(
+      url: "https://github.com/intrusive-memory/SwiftProyecto.git", .upToNextMajor(from: "4.0.0")),
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -64,7 +64,7 @@ let package = Package(
     sibling(
       "SwiftProyecto",
       remote: "https://github.com/intrusive-memory/SwiftProyecto.git",
-      from: "3.5.0"),
+      from: "4.0.0"),
   ],
   targets: [
     .target(

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+---
+type: doc
+---
+
 # SwiftHablare
 
 <p align="center">
@@ -206,7 +210,7 @@ If you have custom VoiceProvider implementations, you must add the `mimeType` pr
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/intrusive-memory/SwiftHablare.git", from: "6.1.1-dev"),
+    .package(url: "https://github.com/intrusive-memory/SwiftHablare.git", from: "6.2.0"),
     .package(url: "https://github.com/intrusive-memory/SwiftCompartido.git", from: "6.6.0")
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ If you have custom VoiceProvider implementations, you must add the `mimeType` pr
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/intrusive-memory/SwiftHablare.git", from: "6.1.1"),
+    .package(url: "https://github.com/intrusive-memory/SwiftHablare.git", from: "6.1.1-dev"),
     .package(url: "https://github.com/intrusive-memory/SwiftCompartido.git", from: "6.6.0")
 ]
 ```

--- a/Sources/SwiftHablare/SwiftHablare.swift
+++ b/Sources/SwiftHablare/SwiftHablare.swift
@@ -81,7 +81,7 @@ import Foundation
 /// There are NO circular dependencies - SwiftCompartido does not depend on SwiftHablare.
 public struct SwiftHablare {
   /// Library version
-  public static let version = "6.1.1-dev"
+  public static let version = "6.2.0"
 
   /// Library name
   public static let name = "SwiftHablare"

--- a/Sources/SwiftHablare/SwiftHablare.swift
+++ b/Sources/SwiftHablare/SwiftHablare.swift
@@ -81,7 +81,7 @@ import Foundation
 /// There are NO circular dependencies - SwiftCompartido does not depend on SwiftHablare.
 public struct SwiftHablare {
   /// Library version
-  public static let version = "6.1.1"
+  public static let version = "6.1.1-dev"
 
   /// Library name
   public static let name = "SwiftHablare"


### PR DESCRIPTION
# Release v6.2.0

## Summary
Raises the SwiftProyecto dependency floor from 3.5.0 to 4.0.0 so downstream consumers can adopt SwiftProyecto 4.x. The library builds and all 219 tests pass against SwiftProyecto 4.1.0 with no source changes required. Package.swift is flipped to its remote-only release form and the version is bumped 6.1.1-dev → 6.2.0.

### New Features
- SwiftProyecto dependency floor raised to `4.0.0` (`.upToNextMajor(from: "4.0.0")`)

### Bug Fixes
- None

### Testing
- 219 tests across 19 suites pass against SwiftProyecto 4.1.0 (`make build` + `make test`)

### Documentation
- AGENTS.md and README.md version references bumped to 6.2.0