### PR TITLE
Release v6.3.0: drop the phantom SwiftProyecto dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This file provides comprehensive documentation for AI agents working with the Sw
 
 ## Quick Reference
 
-- **Current Version**: 6.2.0-dev (check `SwiftHablare.swift` for actual version string)
+- **Current Version**: 6.3.0 (check `SwiftHablare.swift` for actual version string)
 - **Swift Version**: 6.2+
 - **Minimum Deployments**: iOS 26+, macOS 26+
 - **Test Suite**: 229+ passing tests (SwiftHablare)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This file provides comprehensive documentation for AI agents working with the Sw
 
 ## Quick Reference
 
-- **Current Version**: 6.2.0 (check `SwiftHablare.swift` for actual version string)
+- **Current Version**: 6.2.0-dev (check `SwiftHablare.swift` for actual version string)
 - **Swift Version**: 6.2+
 - **Minimum Deployments**: iOS 26+, macOS 26+
 - **Test Suite**: 229+ passing tests (SwiftHablare)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Intrusive Memory
+Copyright (c) 2026 Intrusive Memory
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,3 +19,4 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+

--- a/Package.swift
+++ b/Package.swift
@@ -1,44 +1,6 @@
 // swift-tools-version: 6.2
 
-import Foundation
 import PackageDescription
-
-// In CI we always pin to released remotes. Locally, prefer a sibling checkout
-// at ../<name> if present so in-flight changes can be exercised end-to-end
-// without publishing a release. Falls back to the remote pin if the sibling
-// directory is missing, so fresh clones still build.
-//
-// When this manifest is evaluated as a transitive dependency inside Xcode's
-// `SourcePackages/checkouts/` or SwiftPM's `.build/checkouts/`, every other
-// dependency lives as a sibling in the same directory. Treating those as
-// in-development local paths produces conflicting package identities, so we
-// must skip the sibling shortcut in that context.
-let manifestDir = (#filePath as NSString).deletingLastPathComponent
-let isSPMCheckout =
-  manifestDir.contains("/SourcePackages/checkouts/")
-  || manifestDir.contains("/.build/checkouts/")
-let isCI = ProcessInfo.processInfo.environment["CI"] == "true"
-let useLocalSiblings = !isCI && !isSPMCheckout
-
-func sibling(_ name: String, remote: String, from version: Version) -> Package.Dependency {
-  let localPath = "../\(name)"
-  if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
-    return .package(path: localPath)
-  }
-  return .package(url: remote, .upToNextMajor(from: version))
-}
-
-/// Same sibling-priority pattern as ``sibling(_:remote:from:)`` but pins to a
-/// remote branch when no local sibling exists. Use only when a temporary
-/// pre-release dependency on a feature branch is required; switch back to the
-/// version-pinned ``sibling(_:remote:from:)`` once the upstream tags a release.
-func sibling(_ name: String, remote: String, branch: String) -> Package.Dependency {
-  let localPath = "../\(name)"
-  if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
-    return .package(path: localPath)
-  }
-  return .package(url: remote, branch: branch)
-}
 
 let package = Package(
   name: "SwiftHablare",
@@ -53,20 +15,17 @@ let package = Package(
     )
   ],
   dependencies: [
-    sibling(
-      "SwiftFijos",
-      remote: "https://github.com/intrusive-memory/SwiftFijos.git",
-      from: "1.4.1"),
-    sibling(
-      "SwiftCompartido",
-      remote: "https://github.com/intrusive-memory/SwiftCompartido.git",
-      from: "7.0.4"),
+    .package(
+      url: "https://github.com/intrusive-memory/SwiftFijos.git", .upToNextMajor(from: "1.4.1")),
+    .package(
+      url: "https://github.com/intrusive-memory/SwiftCompartido.git",
+      .upToNextMajor(from: "7.2.4")),
   ],
   targets: [
     .target(
       name: "SwiftHablare",
       dependencies: [
-        .product(name: "SwiftCompartido", package: "SwiftCompartido"),
+        .product(name: "SwiftCompartido", package: "SwiftCompartido")
       ],
       swiftSettings: [
         .enableUpcomingFeature("StrictConcurrency")

--- a/Package.swift
+++ b/Package.swift
@@ -61,17 +61,12 @@ let package = Package(
       "SwiftCompartido",
       remote: "https://github.com/intrusive-memory/SwiftCompartido.git",
       from: "7.0.4"),
-    sibling(
-      "SwiftProyecto",
-      remote: "https://github.com/intrusive-memory/SwiftProyecto.git",
-      from: "4.0.0"),
   ],
   targets: [
     .target(
       name: "SwiftHablare",
       dependencies: [
         .product(name: "SwiftCompartido", package: "SwiftCompartido"),
-        .product(name: "SwiftProyecto", package: "SwiftProyecto"),
       ],
       swiftSettings: [
         .enableUpcomingFeature("StrictConcurrency")

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,44 @@
 // swift-tools-version: 6.2
 
+import Foundation
 import PackageDescription
+
+// In CI we always pin to released remotes. Locally, prefer a sibling checkout
+// at ../<name> if present so in-flight changes can be exercised end-to-end
+// without publishing a release. Falls back to the remote pin if the sibling
+// directory is missing, so fresh clones still build.
+//
+// When this manifest is evaluated as a transitive dependency inside Xcode's
+// `SourcePackages/checkouts/` or SwiftPM's `.build/checkouts/`, every other
+// dependency lives as a sibling in the same directory. Treating those as
+// in-development local paths produces conflicting package identities, so we
+// must skip the sibling shortcut in that context.
+let manifestDir = (#filePath as NSString).deletingLastPathComponent
+let isSPMCheckout =
+  manifestDir.contains("/SourcePackages/checkouts/")
+  || manifestDir.contains("/.build/checkouts/")
+let isCI = ProcessInfo.processInfo.environment["CI"] == "true"
+let useLocalSiblings = !isCI && !isSPMCheckout
+
+func sibling(_ name: String, remote: String, from version: Version) -> Package.Dependency {
+  let localPath = "../\(name)"
+  if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
+    return .package(path: localPath)
+  }
+  return .package(url: remote, .upToNextMajor(from: version))
+}
+
+/// Same sibling-priority pattern as ``sibling(_:remote:from:)`` but pins to a
+/// remote branch when no local sibling exists. Use only when a temporary
+/// pre-release dependency on a feature branch is required; switch back to the
+/// version-pinned ``sibling(_:remote:from:)`` once the upstream tags a release.
+func sibling(_ name: String, remote: String, branch: String) -> Package.Dependency {
+  let localPath = "../\(name)"
+  if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
+    return .package(path: localPath)
+  }
+  return .package(url: remote, branch: branch)
+}
 
 let package = Package(
   name: "SwiftHablare",
@@ -15,12 +53,18 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(
-      url: "https://github.com/intrusive-memory/SwiftFijos.git", .upToNextMajor(from: "1.4.1")),
-    .package(
-      url: "https://github.com/intrusive-memory/SwiftCompartido.git", .upToNextMajor(from: "7.0.4")),
-    .package(
-      url: "https://github.com/intrusive-memory/SwiftProyecto.git", .upToNextMajor(from: "4.0.0")),
+    sibling(
+      "SwiftFijos",
+      remote: "https://github.com/intrusive-memory/SwiftFijos.git",
+      from: "1.4.1"),
+    sibling(
+      "SwiftCompartido",
+      remote: "https://github.com/intrusive-memory/SwiftCompartido.git",
+      from: "7.0.4"),
+    sibling(
+      "SwiftProyecto",
+      remote: "https://github.com/intrusive-memory/SwiftProyecto.git",
+      from: "4.0.0"),
   ],
   targets: [
     .target(

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ If you have custom VoiceProvider implementations, you must add the `mimeType` pr
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/intrusive-memory/SwiftHablare.git", from: "6.2.0-dev"),
+    .package(url: "https://github.com/intrusive-memory/SwiftHablare.git", from: "6.3.0"),
     .package(url: "https://github.com/intrusive-memory/SwiftCompartido.git", from: "6.6.0")
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ If you have custom VoiceProvider implementations, you must add the `mimeType` pr
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/intrusive-memory/SwiftHablare.git", from: "6.2.0"),
+    .package(url: "https://github.com/intrusive-memory/SwiftHablare.git", from: "6.2.0-dev"),
     .package(url: "https://github.com/intrusive-memory/SwiftCompartido.git", from: "6.6.0")
 ]
 ```

--- a/Sources/SwiftHablare/SwiftHablare.swift
+++ b/Sources/SwiftHablare/SwiftHablare.swift
@@ -81,7 +81,7 @@ import Foundation
 /// There are NO circular dependencies - SwiftCompartido does not depend on SwiftHablare.
 public struct SwiftHablare {
   /// Library version
-  public static let version = "6.2.0-dev"
+  public static let version = "6.3.0"
 
   /// Library name
   public static let name = "SwiftHablare"

--- a/Sources/SwiftHablare/SwiftHablare.swift
+++ b/Sources/SwiftHablare/SwiftHablare.swift
@@ -81,7 +81,7 @@ import Foundation
 /// There are NO circular dependencies - SwiftCompartido does not depend on SwiftHablare.
 public struct SwiftHablare {
   /// Library version
-  public static let version = "6.2.0"
+  public static let version = "6.2.0-dev"
 
   /// Library name
   public static let name = "SwiftHablare"


### PR DESCRIPTION
# Release v6.3.0

## Summary
Removes the phantom SwiftProyecto dependency — SwiftHablare never imported it — which lifts the `<5.0.0` SwiftProyecto cap this package imposed on every downstream consumer's dependency graph. Also raises the SwiftCompartido floor to 7.2.4 and adds the MIT LICENSE.

### Bug Fixes
- Remove phantom SwiftProyecto dependency from Package.swift (never imported by any target)

### Dependencies
- SwiftCompartido floor 7.0.4 → 7.2.4
- SwiftFijos confirmed at latest (1.4.1)
- Shipped manifest is remote-only (sibling dev scaffolding stripped)

### Documentation
- MIT LICENSE added
- AGENTS.md / README.md version references updated to 6.3.0