### PR TITLE
Development → Main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This file provides comprehensive documentation for AI agents working with the Sw
 
 ## Quick Reference
 
-- **Current Version**: 6.3.0 (check `SwiftHablare.swift` for actual version string)
+- **Current Version**: 6.3.0-dev (check `SwiftHablare.swift` for actual version string)
 - **Swift Version**: 6.2+
 - **Minimum Deployments**: iOS 26+, macOS 26+
 - **Test Suite**: 229+ passing tests (SwiftHablare)

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,44 @@
 // swift-tools-version: 6.2
 
+import Foundation
 import PackageDescription
+
+// In CI we always pin to released remotes. Locally, prefer a sibling checkout
+// at ../<name> if present so in-flight changes can be exercised end-to-end
+// without publishing a release. Falls back to the remote pin if the sibling
+// directory is missing, so fresh clones still build.
+//
+// When this manifest is evaluated as a transitive dependency inside Xcode's
+// `SourcePackages/checkouts/` or SwiftPM's `.build/checkouts/`, every other
+// dependency lives as a sibling in the same directory. Treating those as
+// in-development local paths produces conflicting package identities, so we
+// must skip the sibling shortcut in that context.
+let manifestDir = (#filePath as NSString).deletingLastPathComponent
+let isSPMCheckout =
+  manifestDir.contains("/SourcePackages/checkouts/")
+  || manifestDir.contains("/.build/checkouts/")
+let isCI = ProcessInfo.processInfo.environment["CI"] == "true"
+let useLocalSiblings = !isCI && !isSPMCheckout
+
+func sibling(_ name: String, remote: String, from version: Version) -> Package.Dependency {
+  let localPath = "../\(name)"
+  if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
+    return .package(path: localPath)
+  }
+  return .package(url: remote, .upToNextMajor(from: version))
+}
+
+/// Same sibling-priority pattern as ``sibling(_:remote:from:)`` but pins to a
+/// remote branch when no local sibling exists. Use only when a temporary
+/// pre-release dependency on a feature branch is required; switch back to the
+/// version-pinned ``sibling(_:remote:from:)`` once the upstream tags a release.
+func sibling(_ name: String, remote: String, branch: String) -> Package.Dependency {
+  let localPath = "../\(name)"
+  if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
+    return .package(path: localPath)
+  }
+  return .package(url: remote, branch: branch)
+}
 
 let package = Package(
   name: "SwiftHablare",
@@ -15,11 +53,14 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(
-      url: "https://github.com/intrusive-memory/SwiftFijos.git", .upToNextMajor(from: "1.4.1")),
-    .package(
-      url: "https://github.com/intrusive-memory/SwiftCompartido.git",
-      .upToNextMajor(from: "7.2.4")),
+    sibling(
+      "SwiftFijos",
+      remote: "https://github.com/intrusive-memory/SwiftFijos.git",
+      from: "1.4.1"),
+    sibling(
+      "SwiftCompartido",
+      remote: "https://github.com/intrusive-memory/SwiftCompartido.git",
+      from: "7.2.4"),
   ],
   targets: [
     .target(

--- a/Sources/SwiftHablare/SwiftHablare.swift
+++ b/Sources/SwiftHablare/SwiftHablare.swift
@@ -81,7 +81,7 @@ import Foundation
 /// There are NO circular dependencies - SwiftCompartido does not depend on SwiftHablare.
 public struct SwiftHablare {
   /// Library version
-  public static let version = "6.3.0"
+  public static let version = "6.3.0-dev"
 
   /// Library name
   public static let name = "SwiftHablare"


### PR DESCRIPTION
## Next Development Cycle

Development branch is synced with main after v6.3.0 release and marked as `6.3.0-dev`.

This PR is in draft mode and will collect changes for the next release. The `-dev` suffix will be stripped when the next version is bumped.